### PR TITLE
Get gas prices from estimation endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etherspot/prime-sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Etherspot Prime (Account Abstraction) SDK",
   "keywords": [
     "ether",

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -155,7 +155,7 @@ export class PrimeSdk {
 
     if (bundlerGasEstimate.preVerificationGas) {
       partialtx.preVerificationGas = BigNumber.from(bundlerGasEstimate.preVerificationGas);
-      partialtx.verificationGasLimit = BigNumber.from(bundlerGasEstimate.verificationGasLimit);
+      partialtx.verificationGasLimit = BigNumber.from(bundlerGasEstimate.verificationGasLimit ?? bundlerGasEstimate.verificationGas);
       partialtx.callGasLimit = BigNumber.from(bundlerGasEstimate.callGasLimit);
     }
 

--- a/src/sdk/sdk.ts
+++ b/src/sdk/sdk.ts
@@ -124,8 +124,6 @@ export class PrimeSdk {
   }
 
   async estimate(gasDetails?: TransactionGasInfoForUserOp) {
-    const gas = await this.getGasFee();
-
     if (this.userOpsBatch.to.length < 1) {
       throw new Error("cannot sign empty transaction batch");
     }
@@ -139,14 +137,25 @@ export class PrimeSdk {
 
     let partialtx = await this.etherspotWallet.createUnsignedUserOp({
       ...tx,
-      ...gas,
+      maxFeePerGas: 1,
+      maxPriorityFeePerGas: 1,
     });
 
     const bundlerGasEstimate = await this.bundler.getVerificationGasInfo(partialtx);
 
+    // if estimation has gas prices use them, otherwise fetch them in a separate call
+    if (bundlerGasEstimate.maxFeePerGas && bundlerGasEstimate.maxPriorityFeePerGas) {
+      partialtx.maxFeePerGas = bundlerGasEstimate.maxFeePerGas;
+      partialtx.maxPriorityFeePerGas = bundlerGasEstimate.maxPriorityFeePerGas;
+    } else {
+      const gas = await this.getGasFee();
+      partialtx.maxFeePerGas = gas.maxFeePerGas;
+      partialtx.maxPriorityFeePerGas = gas.maxPriorityFeePerGas;
+    }
+
     if (bundlerGasEstimate.preVerificationGas) {
       partialtx.preVerificationGas = BigNumber.from(bundlerGasEstimate.preVerificationGas);
-      partialtx.verificationGasLimit = BigNumber.from(bundlerGasEstimate.verificationGas);
+      partialtx.verificationGasLimit = BigNumber.from(bundlerGasEstimate.verificationGasLimit);
       partialtx.callGasLimit = BigNumber.from(bundlerGasEstimate.callGasLimit);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Getting gas prices from `eth_estimateUserOperationGas`. Estimating proper gas prices on L2s require knowing the content of the userop, so it's best to put gas prices in this endpoint.
- Renamed verificationGas to verificationGasLimit, but kept fallback to `verificationGas`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
-

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-
-
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
