### PR TITLE
Adding guardians to etherspot wallet example script

### DIFF
--- a/examples/12-add-guardians.ts
+++ b/examples/12-add-guardians.ts
@@ -1,0 +1,64 @@
+import { ethers } from 'ethers';
+import { PrimeSdk } from '../src';
+import { printOp } from '../src/sdk/common/OperationUtils';
+import * as dotenv from 'dotenv';
+import { sleep } from '../src/sdk/common';
+
+dotenv.config();
+
+async function main() {
+
+  // initializating sdk...
+  const primeSdk = new PrimeSdk({ privateKey: process.env.WALLET_PRIVATE_KEY }, { chainId: Number(process.env.CHAIN_ID), projectKey: '' })
+
+  console.log('address: ', primeSdk.state.walletAddress)
+
+  // get address of EtherspotWallet
+  const address: string = await primeSdk.getCounterFactualAddress();
+
+  // update the addresses in this array with the guardian addresses you want to set
+  let guardianAddresses: string[] = ['0xa8430797A27A652C03C46D5939a8e7698491BEd6', '0xaf2D76acc5B0e496f924B08491444076219F2f35', '0xBF1c0A9F3239f5e7D35cE562Af06c92FB7fdF0DF'];
+
+  console.log('\x1b[33m%s\x1b[0m', `EtherspotWallet address: ${address}`);
+
+  const addGuardianInterface = new ethers.utils.Interface([
+    'function addGuardian(address _newGuardian)'
+  ])
+
+  const addGuardianData1 = addGuardianInterface.encodeFunctionData('addGuardian', [guardianAddresses[0]]);
+  const addGuardianData2 = addGuardianInterface.encodeFunctionData('addGuardian', [guardianAddresses[1]]);
+  const addGuardianData3 = addGuardianInterface.encodeFunctionData('addGuardian', [guardianAddresses[2]]);
+
+  // clear the transaction batch
+  await primeSdk.clearUserOpsFromBatch();
+
+  // add transactions to the batch
+  let userOpsBatch = await primeSdk.addUserOpsToBatch({to: address, data: addGuardianData1});
+  userOpsBatch = await primeSdk.addUserOpsToBatch({to: address, data: addGuardianData2});
+  userOpsBatch = await primeSdk.addUserOpsToBatch({to: address, data: addGuardianData3});
+  console.log('transactions: ', userOpsBatch);
+
+  // sign transactions added to the batch
+  const op = await primeSdk.estimate();
+  console.log(`Estimated UserOp: ${await printOp(op)}`);
+
+  // sign the userOps and sending to the bundler...
+  const uoHash = await primeSdk.send(op);
+  console.log(`UserOpHash: ${uoHash}`);
+
+  // get transaction hash...
+  console.log('Waiting for transaction...');
+  let userOpsReceipt = null;
+  const timeout = Date.now() + 60000; // 1 minute timeout
+  while((userOpsReceipt == null) && (Date.now() < timeout)) {
+    await sleep(2);
+    userOpsReceipt = await primeSdk.getUserOpReceipt(uoHash);
+  }
+  console.log('\x1b[33m%s\x1b[0m', `Transaction Receipt: `, userOpsReceipt);
+
+  
+}
+
+main()
+  .catch(console.error)
+  .finally(() => process.exit());

--- a/examples/12-add-guardians.ts
+++ b/examples/12-add-guardians.ts
@@ -7,23 +7,27 @@ import { sleep } from '../src/sdk/common';
 dotenv.config();
 
 async function main() {
-
   // initializating sdk...
-  const primeSdk = new PrimeSdk({ privateKey: process.env.WALLET_PRIVATE_KEY }, { chainId: Number(process.env.CHAIN_ID), projectKey: '' })
+  const primeSdk = new PrimeSdk(
+    { privateKey: process.env.WALLET_PRIVATE_KEY },
+    { chainId: Number(process.env.CHAIN_ID), projectKey: '' },
+  );
 
-  console.log('address: ', primeSdk.state.walletAddress)
+  console.log('address: ', primeSdk.state.walletAddress);
 
   // get address of EtherspotWallet
   const address: string = await primeSdk.getCounterFactualAddress();
 
   // update the addresses in this array with the guardian addresses you want to set
-  let guardianAddresses: string[] = ['0xa8430797A27A652C03C46D5939a8e7698491BEd6', '0xaf2D76acc5B0e496f924B08491444076219F2f35', '0xBF1c0A9F3239f5e7D35cE562Af06c92FB7fdF0DF'];
+  let guardianAddresses: string[] = [
+    '0xa8430797A27A652C03C46D5939a8e7698491BEd6',
+    '0xaf2D76acc5B0e496f924B08491444076219F2f35',
+    '0xBF1c0A9F3239f5e7D35cE562Af06c92FB7fdF0DF',
+  ];
 
   console.log('\x1b[33m%s\x1b[0m', `EtherspotWallet address: ${address}`);
 
-  const addGuardianInterface = new ethers.utils.Interface([
-    'function addGuardian(address _newGuardian)'
-  ])
+  const addGuardianInterface = new ethers.utils.Interface(['function addGuardian(address _newGuardian)']);
 
   const addGuardianData1 = addGuardianInterface.encodeFunctionData('addGuardian', [guardianAddresses[0]]);
   const addGuardianData2 = addGuardianInterface.encodeFunctionData('addGuardian', [guardianAddresses[1]]);
@@ -33,9 +37,9 @@ async function main() {
   await primeSdk.clearUserOpsFromBatch();
 
   // add transactions to the batch
-  let userOpsBatch = await primeSdk.addUserOpsToBatch({to: address, data: addGuardianData1});
-  userOpsBatch = await primeSdk.addUserOpsToBatch({to: address, data: addGuardianData2});
-  userOpsBatch = await primeSdk.addUserOpsToBatch({to: address, data: addGuardianData3});
+  let userOpsBatch = await primeSdk.addUserOpsToBatch({ to: address, data: addGuardianData1 });
+  userOpsBatch = await primeSdk.addUserOpsToBatch({ to: address, data: addGuardianData2 });
+  userOpsBatch = await primeSdk.addUserOpsToBatch({ to: address, data: addGuardianData3 });
   console.log('transactions: ', userOpsBatch);
 
   // sign transactions added to the batch
@@ -50,13 +54,11 @@ async function main() {
   console.log('Waiting for transaction...');
   let userOpsReceipt = null;
   const timeout = Date.now() + 60000; // 1 minute timeout
-  while((userOpsReceipt == null) && (Date.now() < timeout)) {
+  while (userOpsReceipt == null && Date.now() < timeout) {
     await sleep(2);
     userOpsReceipt = await primeSdk.getUserOpReceipt(uoHash);
   }
   console.log('\x1b[33m%s\x1b[0m', `Transaction Receipt: `, userOpsReceipt);
-
-  
 }
 
 main()

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "09-exchange": "./node_modules/.bin/ts-node ./examples/09-exchange",
     "10-advance-routes-lifi": "./node_modules/.bin/ts-node ./examples/10-advance-routes-lifi",
     "11-cross-chain-quotes": "./node_modules/.bin/ts-node ./examples/11-cross-chain-quotes",
+    "12-add-guardians": "./node_modules/.bin/ts-node ./examples/12-add-guardians",
     "format": "prettier --write \"{src,test,examples}/**/*.ts\"",
     "lint": "eslint \"{src,test}/**/*.ts\"",
     "lint-fix": "npm run lint -- --fix",


### PR DESCRIPTION
## Description
Here I'm adding a script which devs can use to add guardians to their Etherspot wallet. They must replace the 3 addresses in the array with addresses they wish to add. Users can run the script the same way they run other examples in this directory, like this: 

npm run 12-add-guardians

## How Has This Been Tested?

I ran the script and saw the transaction complete successfully on mumbai: https://mumbai.polygonscan.com/tx/0x8cdaa2a6f1114a68758bb60954fab1e0d462c70b927a569e9cc86718dd3db3b4#eventlog 

It does not work to run multiple times with the same addresses as we cannot add the same guardian twice.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
