### PR TITLE
fix: signMessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etherspot/prime-sdk",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Etherspot Prime (Account Abstraction) SDK",
   "keywords": [
     "ether",

--- a/src/sdk/wallet/providers/meta-mask.wallet-provider.ts
+++ b/src/sdk/wallet/providers/meta-mask.wallet-provider.ts
@@ -52,8 +52,8 @@ export class MetaMaskWalletProvider extends DynamicWalletProvider {
 
   async signMessage(message: BytesLike): Promise<string> {
     return this.sendRequest('personal_sign', [
-      this.address, //
       toHex(message),
+      this.address, //
     ]);
   }
 

--- a/src/sdk/wallet/providers/web3.wallet-provider.ts
+++ b/src/sdk/wallet/providers/web3.wallet-provider.ts
@@ -51,8 +51,8 @@ export class Web3WalletProvider extends DynamicWalletProvider {
     return this.sendRequest(
       'personal_sign',
       [
-        this.address, //
         toHex(message),
+        this.address, //
       ],
       this.address,
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in details -->
Sign message rpc parameters should be in the correct order according to the [rpc documentation](https://docs.metamask.io/wallet/how-to/sign-data/#example-1) msg params should always be first

## Types of changes
What types of changes does your code introduce?

- [ X ] Bugfix (non-breaking change which fixes an issue)

## Further comments (optional)
<!--- Additional comments, don't hesitate :) -->

**web3auth integration doesn't work anymore without this fix**

![telegram-cloud-photo-size-4-5916026604100895045-y](https://github.com/etherspot/etherspot-prime-sdk/assets/26006762/7b25eeed-4b32-4e4b-8b79-15d2faf48e85)
