### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/check-package-version.yml
+++ b/.github/workflows/check-package-version.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Check if package version has been updated
         id: check
         uses: EndBug/version-check@v2.1.1

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
           git config --global user.name "EtherspotBOT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded CI workflows to use the latest GitHub Actions checkout version (v5) across version-check and docs deployment pipelines, improving reliability and security.
  * Streamlined maintenance processes with no changes to app behavior or public interfaces.

* **Documentation**
  * Deployment process for docs remains the same; underlying automation updated for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->